### PR TITLE
Test: "지하철 위치에 따른 역 상세정보 기능 구현"

### DIFF
--- a/src/main/java/project/NextStop/config/QuerydslConfig.java
+++ b/src/main/java/project/NextStop/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package project.NextStop.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/project/NextStop/domain/exit/entity/Exit.java
+++ b/src/main/java/project/NextStop/domain/exit/entity/Exit.java
@@ -1,6 +1,7 @@
 package project.NextStop.domain.exit.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import project.NextStop.domain.station.entity.Station;
 
@@ -22,4 +23,18 @@ public class Exit {
 
     @Column(nullable = false)
     private String name;
+
+    protected Exit() {
+    }
+
+    @Builder
+    public Exit(int number, String name) {
+        this.number = number;
+        this.name = name;
+    }
+    //=== 연관관계 메서드 ===//
+    public void addStation(Station station){
+        this.station = station;
+        station.getExits().add(this);
+    }
 }

--- a/src/main/java/project/NextStop/domain/line/entity/Line.java
+++ b/src/main/java/project/NextStop/domain/line/entity/Line.java
@@ -16,4 +16,6 @@ public class Line {
 
     @Column(nullable = false)
     private String tel;
+
+
 }

--- a/src/main/java/project/NextStop/domain/schedule/entity/Schedule.java
+++ b/src/main/java/project/NextStop/domain/schedule/entity/Schedule.java
@@ -1,6 +1,7 @@
 package project.NextStop.domain.schedule.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import project.NextStop.domain.station.entity.StationLine;
 import project.NextStop.domain.subway.entity.Subway;
@@ -31,4 +32,16 @@ public class Schedule {
 
     @Column(nullable = false)
     private String direction;
+
+    protected Schedule() {
+    }
+
+    @Builder
+    public Schedule(StationLine stationLine, Subway subway, String dayStatus, LocalTime arriveTime, String direction){
+        this.stationLine = stationLine;
+        this.subway = subway;
+        this.dayStatus = dayStatus;
+        this.arriveTime = arriveTime;
+        this.direction = direction;
+    }
 }

--- a/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepository.java
@@ -3,5 +3,5 @@ package project.NextStop.domain.schedule.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.NextStop.domain.schedule.entity.Schedule;
 
-public interface ScheduleRepository extends JpaRepository<Schedule,Long> {
+public interface ScheduleRepository extends JpaRepository<Schedule,Long> , ScheduleRepositoryCustom{
 }

--- a/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryCustom.java
@@ -1,0 +1,9 @@
+package project.NextStop.domain.schedule.repository;
+
+import project.NextStop.domain.schedule.entity.Schedule;
+import project.NextStop.domain.station.entity.Station;
+
+public interface ScheduleRepositoryCustom {
+
+    Schedule findStationDetail(Long subwayId);
+}

--- a/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryImpl.java
@@ -1,0 +1,36 @@
+package project.NextStop.domain.schedule.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import project.NextStop.domain.schedule.entity.QSchedule;
+import project.NextStop.domain.schedule.entity.Schedule;
+import project.NextStop.domain.station.entity.QStation;
+import project.NextStop.domain.station.entity.QStationLine;
+import project.NextStop.domain.station.entity.Station;
+import project.NextStop.domain.subway.entity.QSubway;
+
+import java.util.List;
+
+import static project.NextStop.domain.schedule.entity.QSchedule.*;
+import static project.NextStop.domain.station.entity.QStation.*;
+import static project.NextStop.domain.station.entity.QStationLine.*;
+import static project.NextStop.domain.subway.entity.QSubway.*;
+
+public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    public ScheduleRepositoryImpl( JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public Schedule findStationDetail(Long subwayId){
+        return queryFactory
+                .selectFrom(schedule)
+                .join(schedule.subway, subway).fetchJoin()
+                .join(schedule.stationLine, stationLine).fetchJoin()
+                .join(stationLine.next).fetchJoin()
+                .join(stationLine.next.station, station).fetchJoin()
+                .where(schedule.subway.id.eq(subwayId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/project/NextStop/domain/station/entity/Station.java
+++ b/src/main/java/project/NextStop/domain/station/entity/Station.java
@@ -1,10 +1,15 @@
 package project.NextStop.domain.station.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.BatchSize;
+import project.NextStop.domain.exit.entity.Exit;
 import project.NextStop.util.valuetype.Address;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,12 +26,22 @@ public class Station {
     @Column(nullable = false)
     private Address address;
 
-    @Column(nullable = false, precision = 21, scale = 18)
-    private BigDecimal latitude;
-
-    @Column(nullable = false, precision = 21, scale = 18)
-    private BigDecimal longitude;
-
     @Column(nullable = false)
     private Boolean isExpress;
+
+    @OneToMany(mappedBy = "station")
+    @BatchSize(size = 500)
+    private List<Exit> exits = new ArrayList<>();
+
+    protected Station() {
+    }
+
+    @Builder
+    public Station(String name, Address address, Boolean isExpress){
+        this.name = name;
+        this.address = address;
+        this.isExpress = isExpress;
+    }
+
+
 }

--- a/src/main/java/project/NextStop/domain/station/entity/StationLine.java
+++ b/src/main/java/project/NextStop/domain/station/entity/StationLine.java
@@ -1,7 +1,9 @@
 package project.NextStop.domain.station.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.BatchSize;
 import project.NextStop.domain.line.entity.Line;
 
 import java.util.ArrayList;
@@ -32,6 +34,7 @@ public class StationLine {
     private StationLine previous;
 
     @OneToMany(mappedBy = "previous")
+    @BatchSize(size = 500)
     private List<StationLine> previousStationLines = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,5 +42,26 @@ public class StationLine {
     private StationLine next;
 
     @OneToMany(mappedBy = "next")
+    @BatchSize(size = 500)
     private List<StationLine> nextStationLines= new ArrayList<>();
+
+    protected StationLine() {
+    }
+
+    @Builder
+    public StationLine(Station station, String doorDirection){
+        this.station = station;
+        this.doorDirection = doorDirection;
+    }
+
+    //=== 연관관계 메서드 ===//
+    public void addPrevious(StationLine previous){
+        this.previous = previous;
+        previousStationLines.add(previous);
+    }
+
+    public void addNext(StationLine next){
+        this.next = next;
+        nextStationLines.add(next);
+    }
 }

--- a/src/main/java/project/NextStop/domain/subway/entity/Subway.java
+++ b/src/main/java/project/NextStop/domain/subway/entity/Subway.java
@@ -1,6 +1,7 @@
 package project.NextStop.domain.subway.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -17,4 +18,13 @@ public class Subway {
 
     @Column(nullable = false)
     private Boolean isRapid;
+
+    protected Subway() {
+    }
+
+    @Builder
+    public Subway(int number,Boolean isRapid){
+        this.number = number;
+        this.isRapid = isRapid;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     properties:
       hibernate:
 #        show_sql: true
-#        format_sql: true
+        format_sql: true
 
 logging:
   level:

--- a/src/test/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryImplTest.java
+++ b/src/test/java/project/NextStop/domain/schedule/repository/ScheduleRepositoryImplTest.java
@@ -1,0 +1,86 @@
+package project.NextStop.domain.schedule.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import project.NextStop.domain.exit.entity.Exit;
+import project.NextStop.domain.exit.repository.ExitRepository;
+import project.NextStop.domain.schedule.entity.Schedule;
+import project.NextStop.domain.station.entity.Station;
+import project.NextStop.domain.station.entity.StationLine;
+import project.NextStop.domain.station.repository.StationLineRepository;
+import project.NextStop.domain.station.repository.StationRepository;
+import project.NextStop.domain.subway.entity.Subway;
+import project.NextStop.domain.subway.repository.SubwayRepository;
+import project.NextStop.util.valuetype.Address;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class ScheduleRepositoryImplTest {
+
+    @Autowired ScheduleRepository scheduleRepository;
+    @Autowired SubwayRepository subwayRepository;
+    @Autowired StationLineRepository stationLineRepository;
+    @Autowired StationRepository stationRepository;
+    @Autowired ExitRepository exitRepository;
+
+    @Test
+    void findStationDetail(){
+
+        Subway subway = new Subway(3,false);
+        subwayRepository.save(subway);
+
+        Station gundae = new Station("건대입구", new Address("건대로", "서울시", "123"),false);
+        stationRepository.save(gundae);
+
+        Station seungsu = new Station("성수", new Address("성수로", "서울시", "123"),false);
+        stationRepository.save(seungsu);
+
+        Station ttuksom = new Station("뚝섬", new Address("뚝섬로", "서울시", "123"),false);
+        stationRepository.save(ttuksom);
+
+
+        StationLine gundaeLine = new StationLine(gundae, "오른쪽");
+        StationLine seungsuLine = new StationLine(seungsu, "오른쪽");
+        StationLine ttuksomLine = new StationLine(ttuksom, "오른쪽");
+
+        gundaeLine.addNext(seungsuLine);
+        gundaeLine.addPrevious(ttuksomLine);
+
+        stationLineRepository.save(gundaeLine);
+        stationLineRepository.save(seungsuLine);
+        stationLineRepository.save(ttuksomLine);
+
+        Exit exit1 = new Exit(1, "1번 출구");
+        Exit exit2 = new Exit(2, "2번 출구");
+        Exit exit3 = new Exit(3, "3번 출구");
+
+        exit1.addStation(seungsu);
+        exit2.addStation(seungsu);
+        exit3.addStation(seungsu);
+
+        exitRepository.save(exit1);
+        exitRepository.save(exit2);
+        exitRepository.save(exit3);
+
+        Schedule schedule = new Schedule(gundaeLine, subway, "평일", LocalTime.now(), "외선");
+        scheduleRepository.save(schedule);
+
+        Schedule findSchedule = scheduleRepository.findStationDetail(subway.getId());
+        System.out.println("schedule.getStationLine().getNext().getStation().getName() = " + findSchedule.getStationLine().getNext().getStation().getName());
+        List<Exit> exits = findSchedule.getStationLine().getNext().getStation().getExits();
+
+        for (Exit exit : exits) {
+            System.out.println("exit = " + exit.getName());
+        }
+
+    }
+}


### PR DESCRIPTION
외부 API를 통해 지하철이 결정되었을 때 사용자가 다음에 도착할 역에대한 상세정보 나타내는 기능에 대한 테스트 구현

* 각각의 엔티티에 @Builder 패턴이 필요할 것 같아서 적용
* Station -> Exit 로 가는 연관관계가 없었는데 조회시 Station -> Exit로 조회하는 것이 순리에 맞을 것 같아서 단 방향 연관관계를 양 방향 연관관계로 수정
* querydsl 사용을 위한 config 파일 및 커스텀 repository 구현
* 테스트 코드를 리뷰 받은 후 query 수정하고 서비스 로직 구현 예정